### PR TITLE
Add MakeSignature and VerifySignature calls

### DIFF
--- a/ntlm/ntlm.go
+++ b/ntlm/ntlm.go
@@ -179,6 +179,14 @@ func (c *ClientContext) Update(challenge []byte) ([]byte, error) {
 	return authenticate, nil
 }
 
+// Sizes queries the client context for the sizes used in per-message
+// functions. It returns the maximum token size used in authentication
+// exchanges, the maximum signature size, the preferred integral size of
+// messages, the size of any security trailer, and any error.
+func (c *ClientContext) Sizes() (uint32, uint32, uint32, uint32, error) {
+	return c.sctxt.Sizes()
+}
+
 // ServerContext is used by the server to manage all steps of NTLM
 // negotiation. Once authentication is completed the context can be
 // used to impersonate client.
@@ -246,4 +254,12 @@ func (c *ServerContext) ImpersonateUser() error {
 // user to what it was before ImpersonateUser was executed.
 func (c *ServerContext) RevertToSelf() error {
 	return c.sctxt.RevertToSelf()
+}
+
+// Sizes queries the server context for the sizes used in per-message
+// functions. It returns the maximum token size used in authentication
+// exchanges, the maximum signature size, the preferred integral size of
+// messages, the size of any security trailer, and any error.
+func (c *ServerContext) Sizes() (uint32, uint32, uint32, uint32, error) {
+	return c.sctxt.Sizes()
 }

--- a/schannel/attribute.go
+++ b/schannel/attribute.go
@@ -72,3 +72,11 @@ func (c *Client) KeyInfo() (sessionKeySize uint32, sigAlg uint32, sigAlgName str
 	eaname := syscall.UTF16ToString((*[2 << 20]uint16)(unsafe.Pointer(ki.EncryptAlgorithmName))[:])
 	return ki.KeySize, ki.SignatureAlgorithm, saname, ki.EncryptAlgorithm, eaname, nil
 }
+
+// Sizes queries the context for the sizes used in per-message functions.
+// It returns the maximum token size used in authentication exchanges, the
+// maximum signature size, the preferred integral size of messages, the
+// size of any security trailer, and any error.
+func (c *Client) Sizes() (uint32, uint32, uint32, uint32, error) {
+	return c.ctx.Sizes()
+}

--- a/schannel/buffer.go
+++ b/schannel/buffer.go
@@ -76,11 +76,3 @@ func indexOfSecBuffer(bs []sspi.SecBuffer, buftype uint32) int {
 	}
 	return -1
 }
-
-func newSecBufferDesc(b []sspi.SecBuffer) *sspi.SecBufferDesc {
-	return &sspi.SecBufferDesc{
-		Version:      sspi.SECBUFFER_VERSION,
-		BuffersCount: uint32(len(b)),
-		Buffers:      &b[0],
-	}
-}

--- a/schannel/client.go
+++ b/schannel/client.go
@@ -44,11 +44,11 @@ func (c *Client) Handshake(serverName string) error {
 		{BufferType: sspi.SECBUFFER_EMPTY},
 	}
 	// TODO: InitializeSecurityContext doco says that inBufs should be nil on the first call
-	inBufs := newSecBufferDesc(inBuf[:])
+	inBufs := sspi.NewSecBufferDesc(inBuf[:])
 	outBuf := []sspi.SecBuffer{
 		{BufferType: sspi.SECBUFFER_TOKEN},
 	}
-	outBufs := newSecBufferDesc(outBuf)
+	outBufs := sspi.NewSecBufferDesc(outBuf)
 
 	for {
 		ret := c.ctx.Update(name, outBufs, inBufs)
@@ -108,7 +108,7 @@ func (c *Client) writeBlock(data []byte) (int, error) {
 	b[1].Set(sspi.SECBUFFER_DATA, data)
 	b[2].Set(sspi.SECBUFFER_STREAM_TRAILER, make([]byte, ss.Trailer))
 	b[3].Set(sspi.SECBUFFER_EMPTY, nil)
-	ret := sspi.EncryptMessage(c.ctx.Handle, 0, newSecBufferDesc(b[:]), 0)
+	ret := sspi.EncryptMessage(c.ctx.Handle, 0, sspi.NewSecBufferDesc(b[:]), 0)
 	switch ret {
 	case sspi.SEC_E_OK:
 	case sspi.SEC_E_CONTEXT_EXPIRED:
@@ -160,7 +160,7 @@ func (c *Client) Read(data []byte) (int, error) {
 		}
 	}
 	var b [4]sspi.SecBuffer
-	desc := newSecBufferDesc(b[:])
+	desc := sspi.NewSecBufferDesc(b[:])
 loop:
 	for {
 		b[0].Set(sspi.SECBUFFER_DATA, c.inbuf.bytes())
@@ -225,11 +225,11 @@ func (c *Client) Shutdown() error {
 		{BufferType: sspi.SECBUFFER_TOKEN},
 		{BufferType: sspi.SECBUFFER_EMPTY},
 	}
-	inBufs := newSecBufferDesc(inBuf[:])
+	inBufs := sspi.NewSecBufferDesc(inBuf[:])
 	outBuf := []sspi.SecBuffer{
 		{BufferType: sspi.SECBUFFER_TOKEN},
 	}
-	outBufs := newSecBufferDesc(outBuf)
+	outBufs := sspi.NewSecBufferDesc(outBuf)
 	for {
 		// TODO: I am not sure if I can pass nil as targname
 		ret := c.ctx.Update(nil, outBufs, inBufs)

--- a/sspi.go
+++ b/sspi.go
@@ -152,3 +152,26 @@ func (c *Context) RevertToSelf() error {
 	}
 	return nil
 }
+
+// Sizes queries the context for the sizes used in per-message functions.
+// It returns the maximum token size used in authentication exchanges, the
+// maximum signature size, the preferred integral size of messages, the
+// size of any security trailer, and any error.
+func (c *Context) Sizes() (uint32, uint32, uint32, uint32, error) {
+	var s _SecPkgContext_Sizes
+	ret := QueryContextAttributes(c.Handle, _SECPKG_ATTR_SIZES, (*byte)(unsafe.Pointer(&s)))
+	if ret != SEC_E_OK {
+		return 0, 0, 0, 0, ret
+	}
+	return s.MaxToken, s.MaxSignature, s.BlockSize, s.SecurityTrailer, nil
+}
+
+// NewSecBufferDesc returns an initialized SecBufferDesc describing the
+// provided SecBuffer.
+func NewSecBufferDesc(b []SecBuffer) *SecBufferDesc {
+	return &SecBufferDesc{
+		Version:      SECBUFFER_VERSION,
+		BuffersCount: uint32(len(b)),
+		Buffers:      &b[0],
+	}
+}

--- a/syscall.go
+++ b/syscall.go
@@ -25,6 +25,22 @@ const (
 	MICROSOFT_KERBEROS_NAME = "Kerberos"
 	NEGOSSP_NAME            = "Negotiate"
 	UNISP_NAME              = "Microsoft Unified Security Protocol Provider"
+
+	_SECPKG_ATTR_SIZES            = 0
+	_SECPKG_ATTR_NAMES            = 1
+	_SECPKG_ATTR_LIFESPAN         = 2
+	_SECPKG_ATTR_DCE_INFO         = 3
+	_SECPKG_ATTR_STREAM_SIZES     = 4
+	_SECPKG_ATTR_KEY_INFO         = 5
+	_SECPKG_ATTR_AUTHORITY        = 6
+	_SECPKG_ATTR_PROTO_INFO       = 7
+	_SECPKG_ATTR_PASSWORD_EXPIRY  = 8
+	_SECPKG_ATTR_SESSION_KEY      = 9
+	_SECPKG_ATTR_PACKAGE_INFO     = 10
+	_SECPKG_ATTR_USER_FLAGS       = 11
+	_SECPKG_ATTR_NEGOTIATION_INFO = 12
+	_SECPKG_ATTR_NATIVE_NAMES     = 13
+	_SECPKG_ATTR_FLAGS            = 14
 )
 
 type SecPkgInfo struct {
@@ -34,6 +50,13 @@ type SecPkgInfo struct {
 	MaxToken     uint32
 	Name         *uint16
 	Comment      *uint16
+}
+
+type _SecPkgContext_Sizes struct {
+	MaxToken        uint32
+	MaxSignature    uint32
+	BlockSize       uint32
+	SecurityTrailer uint32
 }
 
 //sys	QuerySecurityPackageInfo(pkgname *uint16, pkginfo **SecPkgInfo) (ret syscall.Errno) = secur32.QuerySecurityPackageInfoW


### PR DESCRIPTION
I'm in the process of making some existing GSSAPI code use your SSPI library on Windows. I've used your Negotiate library to establish a context successfully however I now need to use `MakeSignature` & `VerifySignature` and noticed they weren't present.

This PR is the result of me updating `syscall.go` and running `go generate`. I'm not quite sure how/where I'm going to use these either adding them somewhere to your Negotiate library or just calling them from my side with the established context but this should be a start.