### PR TITLE
Correctly handle empty password in AcquireUserCredentials

### DIFF
--- a/negotiate/negotiate.go
+++ b/negotiate/negotiate.go
@@ -67,14 +67,9 @@ func AcquireUserCredentials(domain, username, password string) (*sspi.Credential
 	if err != nil {
 		return nil, err
 	}
-	var p []uint16
-	var plen uint32
-	if len(password) > 0 {
-		p, err = syscall.UTF16FromString(password)
-		if err != nil {
-			return nil, err
-		}
-		plen = uint32(len(p) - 1) // do not count terminating 0
+	p, err := syscall.UTF16FromString(password)
+	if err != nil {
+		return nil, err
 	}
 	ai := sspi.SEC_WINNT_AUTH_IDENTITY{
 		User:           &u[0],
@@ -82,7 +77,7 @@ func AcquireUserCredentials(domain, username, password string) (*sspi.Credential
 		Domain:         &d[0],
 		DomainLength:   uint32(len(d) - 1), // do not count terminating 0
 		Password:       &p[0],
-		PasswordLength: plen,
+		PasswordLength: uint32(len(p) - 1), // do not count terminating 0
 		Flags:          sspi.SEC_WINNT_AUTH_IDENTITY_UNICODE,
 	}
 	return acquireCredentials(sspi.SECPKG_CRED_OUTBOUND, &ai)

--- a/ntlm/ntlm.go
+++ b/ntlm/ntlm.go
@@ -63,14 +63,9 @@ func AcquireUserCredentials(domain, username, password string) (*sspi.Credential
 	if err != nil {
 		return nil, err
 	}
-	var p []uint16
-	var plen uint32
-	if len(password) > 0 {
-		p, err = syscall.UTF16FromString(password)
-		if err != nil {
-			return nil, err
-		}
-		plen = uint32(len(p) - 1) // do not count terminating 0
+	p, err := syscall.UTF16FromString(password)
+	if err != nil {
+		return nil, err
 	}
 	ai := sspi.SEC_WINNT_AUTH_IDENTITY{
 		User:           &u[0],
@@ -78,7 +73,7 @@ func AcquireUserCredentials(domain, username, password string) (*sspi.Credential
 		Domain:         &d[0],
 		DomainLength:   uint32(len(d) - 1), // do not count terminating 0
 		Password:       &p[0],
-		PasswordLength: plen,
+		PasswordLength: uint32(len(p) - 1), // do not count terminating 0
 		Flags:          sspi.SEC_WINNT_AUTH_IDENTITY_UNICODE,
 	}
 	return acquireCredentials(sspi.SECPKG_CRED_OUTBOUND, &ai)


### PR DESCRIPTION
The current code will panic with an index out of bound error when an empty password is passed to AcquireUserCredentials.  It assumes that p is always a valid slice but it is nil when no password is given.  The panic occurs at `Password: &p[0]`.

This change removes the special handling of the empty password.  Thus `syscall.UTF16FromString(password)` is always called which guarantees that p is always a valid slice.

Signed-off-by: Monis Khan <mkhan@redhat.com>