### PR TITLE
Add channel binding support to SSPI context updates

### DIFF
--- a/kerberos/kerberos_test.go
+++ b/kerberos/kerberos_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package kerberos_test

--- a/syscall.go
+++ b/syscall.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package sspi
@@ -96,19 +97,20 @@ type CredHandle struct {
 const (
 	SECURITY_NATIVE_DREP = 16
 
-	SECBUFFER_DATA           = 1
-	SECBUFFER_TOKEN          = 2
-	SECBUFFER_PKG_PARAMS     = 3
-	SECBUFFER_MISSING        = 4
-	SECBUFFER_EXTRA          = 5
-	SECBUFFER_STREAM_TRAILER = 6
-	SECBUFFER_STREAM_HEADER  = 7
-	SECBUFFER_PADDING        = 9
-	SECBUFFER_STREAM         = 10
-	SECBUFFER_READONLY       = 0x80000000
-	SECBUFFER_ATTRMASK       = 0xf0000000
-	SECBUFFER_VERSION        = 0
-	SECBUFFER_EMPTY          = 0
+	SECBUFFER_DATA             = 1
+	SECBUFFER_TOKEN            = 2
+	SECBUFFER_PKG_PARAMS       = 3
+	SECBUFFER_MISSING          = 4
+	SECBUFFER_EXTRA            = 5
+	SECBUFFER_STREAM_TRAILER   = 6
+	SECBUFFER_STREAM_HEADER    = 7
+	SECBUFFER_PADDING          = 9
+	SECBUFFER_STREAM           = 10
+	SECBUFFER_CHANNEL_BINDINGS = 14
+	SECBUFFER_READONLY         = 0x80000000
+	SECBUFFER_ATTRMASK         = 0xf0000000
+	SECBUFFER_VERSION          = 0
+	SECBUFFER_EMPTY            = 0
 
 	ISC_REQ_DELEGATE               = 1
 	ISC_REQ_MUTUAL_AUTH            = 2


### PR DESCRIPTION
Microsoft seems to have turned on the setting that requires channel binding when clients connect to Active Directory in latest updates:
https://support.microsoft.com/en-us/topic/2020-2023-and-2024-ldap-channel-binding-and-ldap-signing-requirements-for-windows-kb4520412-ef185fb8-00f7-167d-744c-f299a66fc00a

This resulted in my go application failing to authenticate.

I have one more change that I am gonna publish on https://github.com/go-ldap as soon as I can get this in, since I use the `go-ldap` library in my application.

I had trouble unit testing this code, but I did manual testing for samba and active directory and saw no issues. Any pointers to how I could write unit tests if needed would be appreciated.